### PR TITLE
Fix buffer overflow

### DIFF
--- a/Core/Src/usbh_ctlreq.c
+++ b/Core/Src/usbh_ctlreq.c
@@ -519,7 +519,7 @@ static void  USBH_ParseInterfaceDesc(USBH_InterfaceDescTypeDef *if_descriptor,
   if_descriptor->bDescriptorType    = *(uint8_t *)(buf + 1);
   if_descriptor->bInterfaceNumber   = *(uint8_t *)(buf + 2);
   if_descriptor->bAlternateSetting  = *(uint8_t *)(buf + 3);
-  if_descriptor->bNumEndpoints      = *(uint8_t *)(buf + 4);
+  if_descriptor->bNumEndpoints      = MIN(*(uint8_t *)(buf + 4), USBH_MAX_NUM_ENDPOINTS);
   if_descriptor->bInterfaceClass    = *(uint8_t *)(buf + 5);
   if_descriptor->bInterfaceSubClass = *(uint8_t *)(buf + 6);
   if_descriptor->bInterfaceProtocol = *(uint8_t *)(buf + 7);


### PR DESCRIPTION
In case the descriptor contains more endpoints than USBH_MAX_NUM_ENDPOINTS the Ep_Desc array and subsequent members of USBH_HandleTypeDef that contains function pointers are overwritten allowing arbitrary code execution.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/stm32_mw_usb_host/blob/master/CONTRIBUTING.md) file.
