### PR TITLE
fix(USBH/CDC): add format specifier to USBH_DbgLog call

### DIFF
--- a/Class/CDC/Src/usbh_cdc.c
+++ b/Class/CDC/Src/usbh_cdc.c
@@ -160,7 +160,7 @@ static USBH_StatusTypeDef USBH_CDC_InterfaceInit(USBH_HandleTypeDef *phost)
 
   if ((interface == 0xFFU) || (interface >= USBH_MAX_NUM_INTERFACES)) /* No Valid Interface */
   {
-    USBH_DbgLog("Cannot Find the interface for Communication Interface Class.", phost->pActiveClass->Name);
+    USBH_DbgLog("Cannot Find the interface for Communication Interface Class[%s].", phost->pActiveClass->Name);
     return USBH_FAIL;
   }
 
@@ -205,7 +205,7 @@ static USBH_StatusTypeDef USBH_CDC_InterfaceInit(USBH_HandleTypeDef *phost)
 
   if ((interface == 0xFFU) || (interface >= USBH_MAX_NUM_INTERFACES)) /* No Valid Interface */
   {
-    USBH_DbgLog("Cannot Find the interface for Data Interface Class.", phost->pActiveClass->Name);
+    USBH_DbgLog("Cannot Find the interface for Data Interface Class[%s].", phost->pActiveClass->Name);
     return USBH_FAIL;
   }
 


### PR DESCRIPTION
- Fix undefined behavior and potential crash in error log path
- The function call was missing a '%s' specifier for the class name argument